### PR TITLE
Add travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+install:
+  - pip install -r test_requirements.txt
+script:
+  - PYTHONPATH=. pytest tests/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ manager (e.g. `apt install git-lfs`).
 
 ## Installation
 
-First, make sure that you have Python 3.5 or newer. Then install `dhSegment` by
+First, make sure that you have Python 3.6 or newer. Then install `dhSegment` by
 following their [installation
 procedure](https://dhsegment.readthedocs.io/en/latest/start/install.html)
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,4 @@
+numpy
+Pillow
+pytest
+responses


### PR DESCRIPTION
I added the .travis.yml file and also had to add a file for test requirements, since `setup.py` cannot be used due to `dh_segment` not being available in PyPI.

Closes #15.